### PR TITLE
fix: improve role form submission feedback

### DIFF
--- a/src/components/templates/form-template.tsx
+++ b/src/components/templates/form-template.tsx
@@ -2,7 +2,11 @@
 
 import { Check, X } from "lucide-react";
 import type { ReactNode } from "react";
-import type { SubmitHandler, UseFormReturn } from "react-hook-form";
+import type {
+  SubmitErrorHandler,
+  SubmitHandler,
+  UseFormReturn,
+} from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -29,6 +33,7 @@ interface FormProps<T extends Record<string, unknown>> {
   children: ReactNode;
   className?: string;
   onSubmit: SubmitHandler<T>;
+  onInvalid?: SubmitErrorHandler<T>;
   form: UseFormReturn<T>;
 }
 
@@ -93,13 +98,15 @@ function Form<T extends Record<string, unknown>>({
   children,
   className,
   onSubmit,
+  onInvalid,
   form,
 }: FormProps<T>) {
+  const submitHandler = onInvalid
+    ? form.handleSubmit(onSubmit, onInvalid)
+    : form.handleSubmit(onSubmit);
+
   return (
-    <form
-      onSubmit={form.handleSubmit(onSubmit)}
-      className={cn("space-y-4", className)}
-    >
+    <form onSubmit={submitHandler} className={cn("space-y-4", className)}>
       {children}
     </form>
   );

--- a/src/components/ui/form-field.tsx
+++ b/src/components/ui/form-field.tsx
@@ -24,7 +24,13 @@ function FormField<T extends FieldValues>({
   disabled,
   children,
 }: FormFieldProps<T>) {
-  const error = form.formState.errors[name]?.message as string | undefined;
+  const fieldError = form.formState.errors[name];
+  const error =
+    typeof fieldError?.message === "string"
+      ? fieldError.message
+      : fieldError
+        ? "Valor inválido"
+        : undefined;
 
   return (
     <div className="space-y-1.5">

--- a/src/features/roles/components/RoleForm.tsx
+++ b/src/features/roles/components/RoleForm.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import type { SubmitErrorHandler } from "react-hook-form";
+import { toast } from "sonner";
 import type { CreateRoleInput } from "@/application/dtos/role/CreateRoleDTO";
 import type { UpdateRoleInput } from "@/application/dtos/role/UpdateRoleDTO";
 import { FormTemplate } from "@/components/templates/form-template";
@@ -29,6 +31,11 @@ export function RoleForm({ mode, roleId }: RoleFormProps) {
 
   type FormData = CreateRoleInput | UpdateRoleInput;
 
+  const handleInvalidSubmit: SubmitErrorHandler<FormData> = (errors) => {
+    console.warn("[RoleForm] validation errors:", errors);
+    toast.error("Revise os campos obrigatórios antes de salvar.");
+  };
+
   if (isFetching) {
     return (
       <div className="flex items-center justify-center h-64">
@@ -39,7 +46,11 @@ export function RoleForm({ mode, roleId }: RoleFormProps) {
 
   return (
     <FormTemplate>
-      <FormTemplate.Form<FormData> form={form} onSubmit={onSubmit}>
+      <FormTemplate.Form<FormData>
+        form={form}
+        onSubmit={onSubmit}
+        onInvalid={handleInvalidSubmit}
+      >
         <FormTemplate.Content>
           <FormField<FormData>
             form={form}

--- a/src/features/roles/hooks/useRoleForm.ts
+++ b/src/features/roles/hooks/useRoleForm.ts
@@ -31,6 +31,10 @@ interface UseRoleFormReturn {
 
 const _defaultPermissions = Object.values(Permission);
 
+function isValidPermission(value: string): value is Permission {
+  return _defaultPermissions.includes(value as Permission);
+}
+
 export function useRoleForm({
   mode,
   roleId,
@@ -61,11 +65,21 @@ export function useRoleForm({
           const data = await response.json();
 
           if (data.ok && data.value) {
+            const validPermissions = (data.value.permissions ?? []).filter(
+              isValidPermission,
+            );
+
             form.reset({
               name: data.value.name,
               description: data.value.description ?? "",
-              permissions: data.value.permissions,
+              permissions: validPermissions,
             });
+
+            if (validPermissions.length !== data.value.permissions.length) {
+              toast.warning(
+                "Algumas permissões antigas foram ignoradas. Revise antes de salvar.",
+              );
+            }
           } else {
             toast.error("Cargo do sistema não encontrado");
             router.push("/roles");
@@ -85,11 +99,19 @@ export function useRoleForm({
     setIsLoading(true);
 
     try {
+      const normalizedPermissions = (formData.permissions ?? []).filter(
+        isValidPermission,
+      );
+      const payload = {
+        ...formData,
+        permissions: normalizedPermissions,
+      };
+
       if (mode === "create") {
         const response = await fetch("/api/roles", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(formData),
+          body: JSON.stringify(payload),
         });
 
         const data = await response.json();
@@ -107,7 +129,7 @@ export function useRoleForm({
         const response = await fetch(`/api/roles/${roleId}`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(formData),
+          body: JSON.stringify(payload),
         });
 
         const data = await response.json();


### PR DESCRIPTION
Add invalid-submit handling and clearer field error fallback so blocked saves are visible.

Sanitize legacy role permissions before reset/submit to avoid silent schema failures during edit.