### PR TITLE
feat: add self-read access for scales

### DIFF
--- a/src/app/(private)/home/page.tsx
+++ b/src/app/(private)/home/page.tsx
@@ -88,6 +88,10 @@ export default function HomePage() {
     requiredPermissions: [Permission.SCALE_READ],
   });
 
+  const { hasPermission: canReadOwnScales } = usePermissions({
+    requiredPermissions: [Permission.SCALE_SELF_READ],
+  });
+
   const { hasPermission: canReadScaleAttendance } = usePermissions({
     requiredPermissions: [Permission.SCALE_ATTENDANCE_READ],
   });
@@ -107,6 +111,7 @@ export default function HomePage() {
 
   const canShowChurchSelfItem = canReadChurchSelf && !canManageChurches;
   const canShowQuickActions =
+    canReadOwnScales ||
     canReadScaleAttendance ||
     canReadScaleAttendanceReport ||
     canShowChurchSelfItem;
@@ -260,6 +265,15 @@ export default function HomePage() {
                   description="Consulte indicadores por período"
                   icon={BarChart3}
                   onClick={() => router.push("/scale-attendance-reports")}
+                />
+              )}
+
+              {canReadOwnScales && !canManageScales && (
+                <CardItem
+                  title="Minhas Escalas"
+                  description="Visualize as escalas em que você está escalado"
+                  icon={ClipboardList}
+                  onClick={() => router.push("/scales")}
                 />
               )}
 

--- a/src/app/(private)/scales/page.tsx
+++ b/src/app/(private)/scales/page.tsx
@@ -1,14 +1,34 @@
 "use client";
 
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 import { Permission } from "@/domain/enums/Permission";
-import { usePermissions } from "@/features/auth/hooks/usePermissions";
+import { useAuth } from "@/features/auth/hooks/useAuth";
 import { ScaleList } from "@/features/scales/components/ScaleList";
 
 export default function ScalesPage() {
-  usePermissions({
-    requiredPermissions: [Permission.SCALE_READ],
-    redirectTo: "/home",
-  });
+  const router = useRouter();
+  const { user, isLoading } = useAuth();
+
+  const canReadScales =
+    user?.isSuperAdmin || user?.permissions.includes(Permission.SCALE_READ);
+  const canReadOwnScales =
+    user?.isSuperAdmin ||
+    user?.permissions.includes(Permission.SCALE_SELF_READ);
+
+  useEffect(() => {
+    if (isLoading || !user) {
+      return;
+    }
+
+    if (!canReadScales && !canReadOwnScales) {
+      router.push("/home");
+    }
+  }, [canReadOwnScales, canReadScales, isLoading, router, user]);
+
+  if (isLoading || (!canReadScales && !canReadOwnScales)) {
+    return null;
+  }
 
   return <ScaleList />;
 }

--- a/src/app/api/scales/[scaleId]/route.ts
+++ b/src/app/api/scales/[scaleId]/route.ts
@@ -20,8 +20,10 @@ export async function GET(
 
   const hasReadAccess =
     user.isSuperAdmin || user.permissions.includes(Permission.SCALE_READ);
+  const hasSelfReadAccess =
+    user.isSuperAdmin || user.permissions.includes(Permission.SCALE_SELF_READ);
 
-  if (!hasReadAccess) {
+  if (!hasReadAccess && !hasSelfReadAccess) {
     return NextResponse.json(
       {
         ok: false,
@@ -44,6 +46,27 @@ export async function GET(
   }
 
   const scale = getResult.value.scale;
+
+  if (!hasReadAccess && hasSelfReadAccess && !user.isSuperAdmin) {
+    const scaleMembers =
+      await scaleContainer.scaleMemberRepository.findByScaleId(scaleId);
+    const isMemberInScale = scaleMembers.some(
+      (member) => member.memberId === user.memberId,
+    );
+
+    if (!isMemberInScale || scale.status !== "published") {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: {
+            code: "NOT_AUTHORIZED",
+            message: "Sem permissão para visualizar esta escala",
+          },
+        },
+        { status: 403 },
+      );
+    }
+  }
 
   if (!user.isSuperAdmin) {
     const hasAccess = user.churches.some((c) => c.churchId === scale.churchId);

--- a/src/app/api/scales/route.ts
+++ b/src/app/api/scales/route.ts
@@ -20,8 +20,10 @@ export async function GET(request: NextRequest) {
 
   const hasReadAccess =
     user.isSuperAdmin || user.permissions.includes(Permission.SCALE_READ);
+  const hasSelfReadAccess =
+    user.isSuperAdmin || user.permissions.includes(Permission.SCALE_SELF_READ);
 
-  if (!hasReadAccess) {
+  if (!hasReadAccess && !hasSelfReadAccess) {
     return NextResponse.json(
       {
         ok: false,
@@ -77,6 +79,39 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(result, {
       status: getHttpStatus(errorCode),
     });
+  }
+
+  if (!hasReadAccess && hasSelfReadAccess && !user.isSuperAdmin) {
+    const scaleIds = result.value.scales.map((scale) => scale.id);
+
+    if (scaleIds.length === 0) {
+      return NextResponse.json(result, { status: 200 });
+    }
+
+    const scaleMembers =
+      await scaleContainer.scaleMemberRepository.findByScaleIds(scaleIds);
+
+    const allowedScaleIds = new Set(
+      scaleMembers
+        .filter((member) => member.memberId === user.memberId)
+        .map((member) => member.scaleId),
+    );
+
+    const filteredScales = result.value.scales.filter(
+      (scale) =>
+        allowedScaleIds.has(scale.id) &&
+        scale.status === "published",
+    );
+
+    return NextResponse.json(
+      {
+        ok: true,
+        value: {
+          scales: filteredScales,
+        },
+      },
+      { status: 200 },
+    );
   }
 
   return NextResponse.json(result, { status: 200 });

--- a/src/components/ui/permission-select.tsx
+++ b/src/components/ui/permission-select.tsx
@@ -27,6 +27,7 @@ const permissionLabels: Record<Permission, string> = {
   [Permission.MEMBER_DELETE]: "Membros: Excluir",
   [Permission.MEMBER_SELF_WRITE]: "Membros: Edição Própria",
   [Permission.SCALE_READ]: "Escalas: Leitura",
+  [Permission.SCALE_SELF_READ]: "Escalas: Minhas escalas",
   [Permission.SCALE_WRITE]: "Escalas: Escrita",
   [Permission.SCALE_DELETE]: "Escalas: Excluir",
   [Permission.SCALE_ATTENDANCE_READ]: "Chamada: Leitura",

--- a/src/domain/enums/Permission.ts
+++ b/src/domain/enums/Permission.ts
@@ -11,6 +11,7 @@ export enum Permission {
   MEMBER_SELF_WRITE = "member:self:write",
 
   SCALE_READ = "scale:read",
+  SCALE_SELF_READ = "scale:self:read",
   SCALE_WRITE = "scale:write",
   SCALE_DELETE = "scale:delete",
   SCALE_ATTENDANCE_READ = "scale_attendance:read",
@@ -52,6 +53,7 @@ export const PermissionGroups = {
   ],
   SCALE: [
     Permission.SCALE_READ,
+    Permission.SCALE_SELF_READ,
     Permission.SCALE_WRITE,
     Permission.SCALE_DELETE,
   ],

--- a/src/features/scales/components/ScaleList.tsx
+++ b/src/features/scales/components/ScaleList.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { ListTemplate } from "@/components/templates/list-template";
 import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/search-input";
+import { Permission } from "@/domain/enums/Permission";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { GenerateScaleDialog } from "./generate-scale-dialog";
 import { ScaleFilter } from "./ScaleFilter";
@@ -29,6 +30,10 @@ export function ScaleList() {
   const router = useRouter();
   const { user } = useAuth();
   const churchId = user?.churchId ?? null;
+  const canWriteScales =
+    user?.isSuperAdmin || user?.permissions.includes(Permission.SCALE_WRITE);
+  const canDeleteScales =
+    user?.isSuperAdmin || user?.permissions.includes(Permission.SCALE_DELETE);
 
   const {
     scales,
@@ -148,10 +153,14 @@ export function ScaleList() {
           icon={Inbox}
           title="Nenhuma escala cadastrada"
           description="Clique em Nova escala para cadastrar a primeira escala da igreja."
-          action={{
-            label: "Cadastrar escala",
-            onClick: handleCreateScale,
-          }}
+          action={
+            canWriteScales
+              ? {
+                  label: "Cadastrar escala",
+                  onClick: handleCreateScale,
+                }
+              : undefined
+          }
         />
       );
     }
@@ -209,11 +218,19 @@ export function ScaleList() {
             tertiary={getServiceTitle(scale.serviceId)}
             status={scale.status}
             description={scale.notes ?? undefined}
-            onClick={() => handleEditScale(scale.id)}
-            actions={{
-              onEdit: () => handleEditScale(scale.id),
-              onDelete: () => handleDeleteScale(scale.id),
-            }}
+            onClick={canWriteScales ? () => handleEditScale(scale.id) : undefined}
+            actions={
+              canWriteScales || canDeleteScales
+                ? {
+                    onEdit: canWriteScales
+                      ? () => handleEditScale(scale.id)
+                      : undefined,
+                    onDelete: canDeleteScales
+                      ? () => handleDeleteScale(scale.id)
+                      : undefined,
+                  }
+                : undefined
+            }
           />
         ))}
       </ListTemplate.List>
@@ -250,13 +267,15 @@ export function ScaleList() {
         )}
       </div>
 
-      <div className="flex justify-end gap-2">
-        <GenerateScaleDialog onSuccess={refresh} />
-        <Button onClick={handleCreateScale}>
-          <Plus className="w-4 h-4 mr-2" />
-          Nova escala
-        </Button>
-      </div>
+      {canWriteScales && (
+        <div className="flex justify-end gap-2">
+          <GenerateScaleDialog onSuccess={refresh} />
+          <Button onClick={handleCreateScale}>
+            <Plus className="w-4 h-4 mr-2" />
+            Nova escala
+          </Button>
+        </div>
+      )}
 
       {renderContent()}
     </ListTemplate>


### PR DESCRIPTION
Introduce a dedicated permission to view only assigned published scales without management rights.

Update API and UI guards so users with self-read can access My Scales safely.