### PR TITLE
feat: add dedicated my scales screen

### DIFF
--- a/src/app/(private)/home/page.tsx
+++ b/src/app/(private)/home/page.tsx
@@ -273,7 +273,7 @@ export default function HomePage() {
                   title="Minhas Escalas"
                   description="Visualize as escalas em que você está escalado"
                   icon={ClipboardList}
-                  onClick={() => router.push("/scales")}
+                  onClick={() => router.push("/my-scales")}
                 />
               )}
 

--- a/src/app/(private)/my-scales/page.tsx
+++ b/src/app/(private)/my-scales/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { Permission } from "@/domain/enums/Permission";
+import { useAuth } from "@/features/auth/hooks/useAuth";
+import { MyScalesScreen } from "@/features/my-scales/components/MyScalesScreen";
+
+export default function MyScalesPage() {
+  const router = useRouter();
+  const { user, isLoading } = useAuth();
+
+  const canReadScales =
+    user?.isSuperAdmin || user?.permissions.includes(Permission.SCALE_READ);
+  const canReadOwnScales =
+    user?.isSuperAdmin ||
+    user?.permissions.includes(Permission.SCALE_SELF_READ);
+
+  useEffect(() => {
+    if (isLoading || !user) {
+      return;
+    }
+
+    if (!canReadScales && !canReadOwnScales) {
+      router.push("/home");
+    }
+  }, [canReadOwnScales, canReadScales, isLoading, router, user]);
+
+  if (isLoading || (!canReadScales && !canReadOwnScales)) {
+    return null;
+  }
+
+  return <MyScalesScreen />;
+}

--- a/src/app/(private)/scales/page.tsx
+++ b/src/app/(private)/scales/page.tsx
@@ -1,34 +1,14 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
 import { Permission } from "@/domain/enums/Permission";
-import { useAuth } from "@/features/auth/hooks/useAuth";
+import { usePermissions } from "@/features/auth/hooks/usePermissions";
 import { ScaleList } from "@/features/scales/components/ScaleList";
 
 export default function ScalesPage() {
-  const router = useRouter();
-  const { user, isLoading } = useAuth();
-
-  const canReadScales =
-    user?.isSuperAdmin || user?.permissions.includes(Permission.SCALE_READ);
-  const canReadOwnScales =
-    user?.isSuperAdmin ||
-    user?.permissions.includes(Permission.SCALE_SELF_READ);
-
-  useEffect(() => {
-    if (isLoading || !user) {
-      return;
-    }
-
-    if (!canReadScales && !canReadOwnScales) {
-      router.push("/home");
-    }
-  }, [canReadOwnScales, canReadScales, isLoading, router, user]);
-
-  if (isLoading || (!canReadScales && !canReadOwnScales)) {
-    return null;
-  }
+  usePermissions({
+    requiredPermissions: [Permission.SCALE_READ],
+    redirectTo: "/home",
+  });
 
   return <ScaleList />;
 }

--- a/src/app/api/my-scales/route.ts
+++ b/src/app/api/my-scales/route.ts
@@ -1,0 +1,181 @@
+import { NextResponse } from "next/server";
+import { Permission } from "@/domain/enums/Permission";
+import { scaleContainer } from "@/infra/di";
+import { getChurchIdFromSession, validateSession } from "../_lib/auth";
+
+interface MyScaleItem {
+  scaleId: string;
+  serviceDate: string;
+  serviceTime: string;
+  ministryName: string;
+  ministryRoleName: string;
+}
+
+function startOfToday(): Date {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+}
+
+export async function GET() {
+  const auth = await validateSession();
+
+  if (!auth.ok) {
+    return NextResponse.json({ ok: false, error: auth.error }, { status: 401 });
+  }
+
+  const { user } = auth;
+  const canReadAll =
+    user.isSuperAdmin || user.permissions.includes(Permission.SCALE_READ);
+  const canReadOwn =
+    user.isSuperAdmin || user.permissions.includes(Permission.SCALE_SELF_READ);
+
+  if (!canReadAll && !canReadOwn) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "NOT_AUTHORIZED",
+          message: "Sem permissão para visualizar escalas",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  const churchId = getChurchIdFromSession(user, null);
+
+  if (!churchId) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "NO_CHURCH_SELECTED",
+          message: "Nenhuma igreja selecionada",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const scales = await scaleContainer.scaleRepository.findByChurchId(churchId);
+  const scaleIds = scales.map((scale) => scale.id);
+
+  if (scaleIds.length === 0) {
+    return NextResponse.json(
+      { ok: true, value: { currentAndFuture: [], past: [] } },
+      { status: 200 },
+    );
+  }
+
+  const scaleMembers = await scaleContainer.scaleMemberRepository.findByScaleIds(
+    scaleIds,
+  );
+  const myScaleMembers = scaleMembers.filter(
+    (scaleMember) => scaleMember.memberId === user.memberId,
+  );
+
+  if (myScaleMembers.length === 0) {
+    return NextResponse.json(
+      { ok: true, value: { currentAndFuture: [], past: [] } },
+      { status: 200 },
+    );
+  }
+
+  const scaleById = new Map(scales.map((scale) => [scale.id, scale]));
+
+  const serviceIds = Array.from(
+    new Set(
+      myScaleMembers
+        .map((scaleMember) => scaleById.get(scaleMember.scaleId)?.serviceId)
+        .filter((serviceId): serviceId is string => Boolean(serviceId)),
+    ),
+  );
+
+  const ministryIds = Array.from(
+    new Set(
+      myScaleMembers
+        .map((scaleMember) => scaleById.get(scaleMember.scaleId)?.ministryId)
+        .filter((ministryId): ministryId is string => Boolean(ministryId)),
+    ),
+  );
+
+  const ministryRoleIds = Array.from(
+    new Set(myScaleMembers.map((scaleMember) => scaleMember.ministryRoleId)),
+  );
+
+  const [services, ministries, ministryRoles] = await Promise.all([
+    Promise.all(
+      serviceIds.map((serviceId) => scaleContainer.serviceRepository.findById(serviceId)),
+    ),
+    Promise.all(
+      ministryIds.map((ministryId) =>
+        scaleContainer.ministryRepository.findById(ministryId),
+      ),
+    ),
+    Promise.all(
+      ministryRoleIds.map((ministryRoleId) =>
+        scaleContainer.ministryRoleRepository.findById(ministryRoleId),
+      ),
+    ),
+  ]);
+
+  const serviceById = new Map(services.filter(Boolean).map((service) => [service.id, service]));
+  const ministryById = new Map(
+    ministries.filter(Boolean).map((ministry) => [ministry.id, ministry]),
+  );
+  const ministryRoleById = new Map(
+    ministryRoles.filter(Boolean).map((ministryRole) => [ministryRole.id, ministryRole]),
+  );
+
+  const today = startOfToday();
+
+  const items: MyScaleItem[] = myScaleMembers
+    .map((scaleMember) => {
+      const scale = scaleById.get(scaleMember.scaleId);
+      if (!scale || scale.status !== "published") {
+        return null;
+      }
+
+      const service = serviceById.get(scale.serviceId);
+      const ministry = ministryById.get(scale.ministryId);
+      const ministryRole = ministryRoleById.get(scaleMember.ministryRoleId);
+
+      if (!service || !ministry || !ministryRole) {
+        return null;
+      }
+
+      return {
+        scaleId: scale.id,
+        serviceDate: service.date.toISOString(),
+        serviceTime: service.time,
+        ministryName: ministry.name,
+        ministryRoleName: ministryRole.name,
+      };
+    })
+    .filter((item): item is MyScaleItem => item !== null);
+
+  const currentAndFuture = items
+    .filter((item) => new Date(item.serviceDate) >= today)
+    .sort(
+      (a, b) =>
+        new Date(a.serviceDate).getTime() - new Date(b.serviceDate).getTime(),
+    );
+
+  const past = items
+    .filter((item) => new Date(item.serviceDate) < today)
+    .sort(
+      (a, b) =>
+        new Date(b.serviceDate).getTime() - new Date(a.serviceDate).getTime(),
+    );
+
+  return NextResponse.json(
+    {
+      ok: true,
+      value: {
+        currentAndFuture,
+        past,
+      },
+    },
+    { status: 200 },
+  );
+}

--- a/src/app/api/my-scales/route.ts
+++ b/src/app/api/my-scales/route.ts
@@ -11,6 +11,10 @@ interface MyScaleItem {
   ministryRoleName: string;
 }
 
+function isNonNullable<T>(value: T | null | undefined): value is T {
+  return value != null;
+}
+
 function startOfToday(): Date {
   const now = new Date();
   return new Date(now.getFullYear(), now.getMonth(), now.getDate());
@@ -119,12 +123,18 @@ export async function GET() {
     ),
   ]);
 
-  const serviceById = new Map(services.filter(Boolean).map((service) => [service.id, service]));
+  const serviceById = new Map(
+    services.filter(isNonNullable).map((service) => [service.id, service]),
+  );
   const ministryById = new Map(
-    ministries.filter(Boolean).map((ministry) => [ministry.id, ministry]),
+    ministries
+      .filter(isNonNullable)
+      .map((ministry) => [ministry.id, ministry]),
   );
   const ministryRoleById = new Map(
-    ministryRoles.filter(Boolean).map((ministryRole) => [ministryRole.id, ministryRole]),
+    ministryRoles
+      .filter(isNonNullable)
+      .map((ministryRole) => [ministryRole.id, ministryRole]),
   );
 
   const today = startOfToday();

--- a/src/features/my-scales/components/MyScalesScreen.tsx
+++ b/src/features/my-scales/components/MyScalesScreen.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { CalendarDays, Clock3 } from "lucide-react";
+import { PrivateHeader } from "@/components/modules/private-header";
+import { cn } from "@/lib/utils";
+import { useMyScales } from "../hooks/useMyScales";
+
+function formatDateLabel(dateIso: string): string {
+  const date = new Date(dateIso);
+  return date.toLocaleDateString("pt-BR", {
+    weekday: "short",
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
+export function MyScalesScreen() {
+  const { activeTab, setActiveTab, isLoading, currentAndFuture, past } =
+    useMyScales();
+
+  const items = activeTab === "current" ? currentAndFuture : past;
+
+  return (
+    <div className="min-h-screen app-background">
+      <div className="mx-auto max-w-2xl p-4 pb-6">
+        <PrivateHeader
+          title="Minhas Escalas"
+          subtitle="Veja onde voce esta escalado"
+          backHref="/home"
+        />
+
+        <div className="mb-4 mt-4 grid grid-cols-2 gap-2 rounded-xl border border-border bg-card p-1">
+          <button
+            type="button"
+            onClick={() => setActiveTab("current")}
+            className={cn(
+              "h-10 rounded-lg text-sm font-medium transition-colors",
+              activeTab === "current"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-muted",
+            )}
+          >
+            Atuais e futuras
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveTab("past")}
+            className={cn(
+              "h-10 rounded-lg text-sm font-medium transition-colors",
+              activeTab === "past"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-muted",
+            )}
+          >
+            Passadas
+          </button>
+        </div>
+
+        {isLoading ? (
+          <div className="flex h-40 items-center justify-center">
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          </div>
+        ) : items.length === 0 ? (
+          <div className="rounded-xl border border-border bg-card p-6 text-center">
+            <p className="text-sm text-muted-foreground">
+              {activeTab === "current"
+                ? "Nenhuma escala atual ou futura encontrada."
+                : "Nenhuma escala passada encontrada."}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {items.map((item) => (
+              <article
+                key={`${item.scaleId}-${item.ministryRoleName}`}
+                className="rounded-xl border border-border bg-card p-4"
+              >
+                <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-foreground">
+                  <CalendarDays className="h-4 w-4 text-primary" />
+                  <span>{formatDateLabel(item.serviceDate)}</span>
+                  <span className="text-muted-foreground">-</span>
+                  <span>{item.serviceTime}</span>
+                </div>
+
+                <div className="grid gap-2 text-sm">
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                      Ministerio
+                    </p>
+                    <p className="text-foreground">{item.ministryName}</p>
+                  </div>
+
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                      Funcao
+                    </p>
+                    <p className="flex items-center gap-1 text-foreground">
+                      <Clock3 className="h-3.5 w-3.5 text-primary" />
+                      {item.ministryRoleName}
+                    </p>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/my-scales/hooks/useMyScales.ts
+++ b/src/features/my-scales/hooks/useMyScales.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export interface MyScaleItem {
+  scaleId: string;
+  serviceDate: string;
+  serviceTime: string;
+  ministryName: string;
+  ministryRoleName: string;
+}
+
+type TabKey = "current" | "past";
+
+interface UseMyScalesReturn {
+  activeTab: TabKey;
+  setActiveTab: (tab: TabKey) => void;
+  isLoading: boolean;
+  currentAndFuture: MyScaleItem[];
+  past: MyScaleItem[];
+}
+
+export function useMyScales(): UseMyScalesReturn {
+  const [activeTab, setActiveTab] = useState<TabKey>("current");
+  const [isLoading, setIsLoading] = useState(true);
+  const [currentAndFuture, setCurrentAndFuture] = useState<MyScaleItem[]>([]);
+  const [past, setPast] = useState<MyScaleItem[]>([]);
+
+  const fetchMyScales = useCallback(async () => {
+    setIsLoading(true);
+
+    try {
+      const response = await fetch("/api/my-scales");
+      const data = await response.json();
+
+      if (!response.ok || !data.ok) {
+        setCurrentAndFuture([]);
+        setPast([]);
+        return;
+      }
+
+      setCurrentAndFuture(data.value.currentAndFuture ?? []);
+      setPast(data.value.past ?? []);
+    } catch {
+      setCurrentAndFuture([]);
+      setPast([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchMyScales();
+  }, [fetchMyScales]);
+
+  return useMemo(
+    () => ({
+      activeTab,
+      setActiveTab,
+      isLoading,
+      currentAndFuture,
+      past,
+    }),
+    [activeTab, isLoading, currentAndFuture, past],
+  );
+}

--- a/src/features/scales/components/ScaleList.tsx
+++ b/src/features/scales/components/ScaleList.tsx
@@ -26,7 +26,11 @@ interface MinistryOption {
   name: string;
 }
 
-export function ScaleList() {
+interface ScaleListProps {
+  viewMode?: "all" | "my";
+}
+
+export function ScaleList({ viewMode = "all" }: ScaleListProps) {
   const router = useRouter();
   const { user } = useAuth();
   const churchId = user?.churchId ?? null;
@@ -148,11 +152,20 @@ export function ScaleList() {
 
   const renderContent = () => {
     if (allScalesCount === 0 && !isLoading) {
+      const emptyTitle =
+        viewMode === "my"
+          ? "Você não está em nenhuma escala"
+          : "Nenhuma escala cadastrada";
+      const emptyDescription =
+        viewMode === "my"
+          ? "Quando você for escalado, suas escalas aparecerão aqui."
+          : "Clique em Nova escala para cadastrar a primeira escala da igreja.";
+
       return (
         <ListTemplate.EmptyState
           icon={Inbox}
-          title="Nenhuma escala cadastrada"
-          description="Clique em Nova escala para cadastrar a primeira escala da igreja."
+          title={emptyTitle}
+          description={emptyDescription}
           action={
             canWriteScales
               ? {
@@ -240,7 +253,7 @@ export function ScaleList() {
   return (
     <ListTemplate isLoading={isLoading}>
       <ListTemplate.Header
-        title="Escalas"
+        title={viewMode === "my" ? "Minhas Escalas" : "Escalas"}
         subtitle={`${allScalesCount} escala${allScalesCount !== 1 ? "s" : ""}`}
       />
 


### PR DESCRIPTION
Create a separate My Scales experience with current/future and past tabs, showing only assigned published scales.

Include service date, service time, ministry, and role details, and fix home navigation to the new route.